### PR TITLE
Update AGP version to 8.12.0 in libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 aboutlibraries = "11.1.4"
-agp = "8.11.1"
+agp = "8.12.0"
 appcompat = "1.7.0"
 codeview = "1.3.9"
 datastore = "1.1.1"


### PR DESCRIPTION
The Android Gradle Plugin (AGP) version has been updated from 8.11.1 to 8.12.0 in the `gradle/libs.versions.toml` file.